### PR TITLE
Fix building with libtasn1 < 3.1

### DIFF
--- a/contrib/spnego/spnego.asn1
+++ b/contrib/spnego/spnego.asn1
@@ -1,7 +1,9 @@
 -- This file has been taken from heimdal gssapi implementation
 -- and modified by Julien 'Lta' BALLET <contact@lta.io> to work with libtasn1
 
-SPNEGO DEFINITIONS EXPLICIT TAGS ::=
+SPNEGO { }
+
+DEFINITIONS EXPLICIT TAGS ::=
 BEGIN
 
 MechType ::= OBJECT IDENTIFIER

--- a/contrib/spnego/spnego_asn1.h
+++ b/contrib/spnego/spnego_asn1.h
@@ -4,6 +4,6 @@
 
 #include <libtasn1.h>
 
-extern const asn1_static_node spnego_asn1_conf[];
+extern const ASN1_ARRAY_TYPE spnego_asn1_conf[];
 
 #endif


### PR DESCRIPTION
The data type ASN1_ARRAY_TYPE is deprecated, but still available
in current versions of libtasn1.

This fixes building with the version of libtasn1 from current
debian stable.
