### PR TITLE
List all the debian build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ few useless (yet) utils are also provided.
 * getopt_long
 * GNU asn1 compiler/support library
 
-Most of it can be installed on Debian(-based) systems using
+The build dependencies can be installed on Debian(-based) systems using
 
-    sudo apt-get install build-essential
+    sudo apt-get install build-essential autoconf gettext libtool pkg-config libtasn1-3-dev libtasn1-3-bin libbsd-dev
 
 ### HowTo
 


### PR DESCRIPTION
These have been tested on a debootstrap based install of
debian wheezy.

The gettext dependency is only required for some m4 macros
used in m4/iconv.m4 - to avoid it, the lib-prefix.m4 and
lib-link.m4 files from gettext could be bundled as well.
