### PR TITLE
Change the return value of a function to void

### DIFF
--- a/bin/ntlm_test.c
+++ b/bin/ntlm_test.c
@@ -29,7 +29,7 @@
 #include "bdsm/debug.h"
 #include "bdsm/smb_ntlm.h"
 
-int hexprint(const char *name, const char *data, size_t data_sz)
+void hexprint(const char *name, const char *data, size_t data_sz)
 {
   printf("%s =", name);
 


### PR DESCRIPTION
This avoids a warning about control reaching the end of a non-void
function.
