### PR TITLE
Make the rc4 implementation slightly more portable

### DIFF
--- a/contrib/rc4/rc4.c
+++ b/contrib/rc4/rc4.c
@@ -39,9 +39,9 @@
 #include "rc4/rc4.h"
 
 static __inline void
-swap_bytes(u_char *a, u_char *b)
+swap_bytes(uint8_t *a, uint8_t *b)
 {
-    u_char temp;
+    uint8_t temp;
 
     temp = *a;
     *a = *b;
@@ -53,14 +53,14 @@ swap_bytes(u_char *a, u_char *b)
  * which can have arbitrary length.
  */
 void
-rc4_init(struct rc4_state *const state, const u_char *key, int keylen)
+rc4_init(struct rc4_state *const state, const uint8_t *key, int keylen)
 {
-    u_char j;
+    uint8_t j;
     int i;
 
     /* Initialize state with identity permutation */
     for (i = 0; i < 256; i++)
-        state->perm[i] = (u_char)i;
+        state->perm[i] = (uint8_t)i;
     state->index1 = 0;
     state->index2 = 0;
 
@@ -80,10 +80,10 @@ rc4_init(struct rc4_state *const state, const u_char *key, int keylen)
  */
 void
 rc4_crypt(struct rc4_state *const state,
-          const u_char *inbuf, u_char *outbuf, int buflen)
+          const uint8_t *inbuf, uint8_t *outbuf, int buflen)
 {
     int i;
-    u_char j;
+    uint8_t j;
 
     for (i = 0; i < buflen; i++)
     {

--- a/contrib/rc4/rc4.h
+++ b/contrib/rc4/rc4.h
@@ -39,18 +39,18 @@
 #ifndef _SYS_CRYPTO_RC4_RC4_H_
 #define _SYS_CRYPTO_RC4_RC4_H_
 
-#include <sys/types.h>
+#include <stdint.h>
 
 struct rc4_state
 {
-    u_char  perm[256];
-    u_char  index1;
-    u_char  index2;
+    uint8_t  perm[256];
+    uint8_t  index1;
+    uint8_t  index2;
 };
 
-extern void rc4_init(struct rc4_state *state, const u_char *key, int keylen);
+extern void rc4_init(struct rc4_state *state, const uint8_t *key, int keylen);
 extern void rc4_crypt(struct rc4_state *state,
-                      const u_char *inbuf, u_char *outbuf, int buflen);
+                      const uint8_t *inbuf, uint8_t *outbuf, int buflen);
 
 #endif
 


### PR DESCRIPTION
Don't require the user of the code to include any special header beforehand, use standard C99 types instead of the nonstandard u_char type.
