### PR TITLE
Pass a smb_ntlmh* to functions instead of a smb_ntlmh itself

### DIFF
--- a/bin/ntlm_test.c
+++ b/bin/ntlm_test.c
@@ -78,8 +78,8 @@ int main(int argc, char const *argv[])
   ntlm2 = smb_ntlm2_response(&hashv2, srv_challenge, &buf);
   //smb_ntlm2_session_key(&hashv2, ntlm2, &session_key);
 
-  smb_ntlm_generate_xkey(xkey);
-  smb_ntlm2_session_key(&hashv2, ntlm2, xkey, xkey_crypt);
+  smb_ntlm_generate_xkey(&xkey);
+  smb_ntlm2_session_key(&hashv2, ntlm2, &xkey, &xkey_crypt);
 
 
   // MD4_CTX ctx;


### PR DESCRIPTION
Since smb_ntlmh is typedeffed to uint8_t[SMB_NTLM_HASH_SIZE],
this will actually send the exact same pointer, but clang warns
about the difference in type signature.

Technically, all functions taking a 'smb_ntlmh*' could just as well
be taking a 'smb_ntlmh' instead.
