### PR TITLE
Update the list of dependencies now that some m4 files are bundled

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ few useless (yet) utils are also provided.
 
 The build dependencies can be installed on Debian(-based) systems using
 
-    sudo apt-get install build-essential autoconf gettext libtool pkg-config libtasn1-3-dev libtasn1-3-bin libbsd-dev
+    sudo apt-get install build-essential autoconf libtool pkg-config libtasn1-3-dev libtasn1-3-bin libbsd-dev
 
 ### HowTo
 


### PR DESCRIPTION
Now gettext isn't necessary for building on debian stable any longer.
