### PR TITLE
build: check for clock_gettime presence in librt for old glibc versions.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -87,6 +87,7 @@ AS_IF([test x"$HAVE_TASN1_3PLUS" = x"yes"], [
 AC_SEARCH_LIBS([strlcpy], [bsd], [
   AC_DEFINE([HAVE_LIBBSD], [1], [Does this system have libbsd strl*** functions implementation])
 ])
+AC_SEARCH_LIBS([clock_gettime], [rt])
 AC_REPLACE_FUNCS([strlcpy])
 AC_REPLACE_FUNCS([clock_gettime])
 


### PR DESCRIPTION
Should fix issue #32.