### PR TITLE
Fix for issues in #40

### DIFF
--- a/src/netbios_session.c
+++ b/src/netbios_session.c
@@ -318,6 +318,12 @@ ssize_t           netbios_session_packet_recv(netbios_session *s, void **data)
 
     size = netbios_session_get_next_packet(s);
 
+    // If received message is a keepalive, ignore message and get next one
+    while (s->packet_recv->opcode == NETBIOS_OP_SESSION_KEEPALIVE)
+    {
+        size = netbios_session_get_next_packet(s);
+    }
+
     if ((size > 0) && (data != NULL))
         *data = (void *) s->packet_recv->payload;
 

--- a/src/netbios_session.h
+++ b/src/netbios_session.h
@@ -53,14 +53,17 @@ typedef struct              netbios_session_s
     int                         socket;
     // The current sessions state; See macro before (eg. NETBIOS_SESSION_ERROR)
     int                         state;
-    // What are the sizes of the allocated payloads;
+    // What is the size of the allocated payload;
     size_t                      packet_send_payload_size;
     size_t                      packet_recv_payload_size;
     // Where is the write cursor relative to the beginning of the payload
     size_t                      packet_send_cursor;
-    // Our allocated packets
+    // Our allocated packet, this is where the magic happen (both send and recv :)
     netbios_session_packet      *packet_send;
     netbios_session_packet      *packet_recv;
+    // Info about next message received in buffer
+    size_t                      packet_recv_next_offset;
+    size_t                      packet_recv_size_next_msg;
 }                           netbios_session;
 
 

--- a/src/netbios_session.h
+++ b/src/netbios_session.h
@@ -53,12 +53,14 @@ typedef struct              netbios_session_s
     int                         socket;
     // The current sessions state; See macro before (eg. NETBIOS_SESSION_ERROR)
     int                         state;
-    // What is the size of the allocated payload;
-    size_t                      packet_payload_size;
+    // What are the sizes of the allocated payloads;
+    size_t                      packet_send_payload_size;
+    size_t                      packet_recv_payload_size;
     // Where is the write cursor relative to the beginning of the payload
-    size_t                      packet_cursor;
-    // Our allocated packet, this is where the magic happen (both send and recv :)
-    netbios_session_packet      *packet;
+    size_t                      packet_send_cursor;
+    // Our allocated packets
+    netbios_session_packet      *packet_send;
+    netbios_session_packet      *packet_recv;
 }                           netbios_session;
 
 

--- a/src/smb_file.c
+++ b/src/smb_file.c
@@ -189,12 +189,12 @@ ssize_t   smb_fread(smb_session *s, smb_fd fd, void *buf, size_t buf_size)
     SMB_MSG_INIT_PKT_ANDX(req);
     req.wct              = 12;
     req.fid              = file->fid;
-    req.offset           = file->readp;
+    req.offset           = (uint32_t)(file->readp);
     req.max_count        = max_read;
     req.min_count        = max_read;
     req.max_count_high   = 0;
     req.remaining        = 0;
-    req.offset_high      = 0;
+    req.offset_high      = (uint32_t)(file->readp >> 32);
     req.bct              = 0;
     SMB_MSG_PUT_PKT(req_msg, req);
 

--- a/src/smb_session_msg.h
+++ b/src/smb_session_msg.h
@@ -36,7 +36,7 @@
 // Send a smb message for the provided smb_session
 int             smb_session_send_msg(smb_session *s, smb_message *msg);
 
-// msg->packet will be updated to point on received data. You don't own this
+// msg->packet_recv will be updated to point on received data. You don't own this
 // memory. It'll be reused on next recv_msg
 ssize_t         smb_session_recv_msg(smb_session *s, smb_message *msg);
 

--- a/src/smb_types.h
+++ b/src/smb_types.h
@@ -64,7 +64,7 @@ struct smb_file
     uint64_t            alloc_size;
     uint64_t            size;
     uint32_t            attr;
-    uint32_t            readp;          // Current read pointer (position);
+    size_t              readp;          // Current read pointer (position);
     int                 is_dir;         // 0 -> file, 1 -> directory
 };
 


### PR DESCRIPTION
This commit fix several issues (#40) :
- It was possible to lose some messages if first socket read was reading a keep alive message followed by an answer to a request (this was causing possible file corruption when receiving keepalive message)
- keepalive messages have to be ignored
- reading file data above the 4GiB limit was not working

To fix this, I had to use different buffers for sent and received messages as we don't want that a message to send override some data not yet processed in receive buffer.

I've tested my modifications with a server sending keep alive messages every seconds (instead of every 300s) to make sure that everything is working well ...