### PR TITLE
Fix for issues in #40 (v2)

### DIFF
--- a/src/smb_file.c
+++ b/src/smb_file.c
@@ -194,7 +194,7 @@ ssize_t   smb_fread(smb_session *s, smb_fd fd, void *buf, size_t buf_size)
     req.min_count        = max_read;
     req.max_count_high   = 0;
     req.remaining        = 0;
-    req.offset_high      = 0;
+    req.offset_high      = (file->readp >> 32) & 0xffffffff;
     req.bct              = 0;
     SMB_MSG_PUT_PKT(req_msg, req);
 

--- a/src/smb_types.h
+++ b/src/smb_types.h
@@ -64,7 +64,7 @@ struct smb_file
     uint64_t            alloc_size;
     uint64_t            size;
     uint32_t            attr;
-    uint32_t            readp;          // Current read pointer (position);
+    uint64_t            readp;          // Current read pointer (position);
     int                 is_dir;         // 0 -> file, 1 -> directory
 };
 


### PR DESCRIPTION
This commit fix several issues (see #40) :
- It was possible to lose some messages if first socket read was reading a keep alive message followed by an answer to a request (this was causing possible file corruption when receiving keepalive message)
- keepalive messages have to be ignored
- reading file data above the 4GiB limit was not working

I've tested my modifications with a server sending keep alive messages every seconds (instead of every 300s) to make sure that everything is working well ...

Thanks @tguillem for your remarks and your idea to simplify my patch !