### PR TITLE
Fix share connect issue if server returns a tid equal to 0

### DIFF
--- a/include/bdsm/smb_types.h
+++ b/include/bdsm/smb_types.h
@@ -45,7 +45,7 @@
   * @struct smb_tid
   * @brief The id of a connection to a share within a session.
   */
-typedef uint16_t    smb_tid;
+typedef int32_t    smb_tid;
 
 /**
   * @struct smb_fid

--- a/src/smb_fd.c
+++ b/src/smb_fd.c
@@ -54,7 +54,7 @@ smb_share *smb_session_share_get(smb_session *s, smb_tid tid)
 {
     smb_share *iter;
 
-    assert(s != NULL && tid);
+    assert(s != NULL && tid != -1);
 
     iter = s->shares;
     while (iter != NULL && iter->tid != tid)
@@ -67,7 +67,7 @@ smb_share *smb_session_share_remove(smb_session *s, smb_tid tid)
 {
     smb_share *iter, *keep;
 
-    assert(s != NULL && tid);
+    assert(s != NULL && tid != -1);
     iter = s->shares;
 
     if (iter == NULL)
@@ -121,7 +121,7 @@ int         smb_session_file_add(smb_session *s, smb_tid tid, smb_file *f)
     smb_share *share;
     smb_file  *iter;
 
-    assert(s != NULL && tid && f != NULL);
+    assert(s != NULL && tid != -1 && f != NULL);
 
     if ((share = smb_session_share_get(s, tid)) == NULL)
         return (0);

--- a/src/smb_file.c
+++ b/src/smb_file.c
@@ -66,7 +66,7 @@ smb_fd      smb_fopen(smb_session *s, smb_tid tid, const char *path,
     }
 
     // Set SMB Headers
-    req_msg->packet->header.tid = tid;
+    req_msg->packet->header.tid = (uint16_t)tid;
 
     // Create AndX Params
     SMB_MSG_INIT_PKT_ANDX(req);
@@ -144,7 +144,7 @@ void        smb_fclose(smb_session *s, smb_fd fd)
         return;
     }
 
-    msg->packet->header.tid = SMB_FD_TID(fd);
+    msg->packet->header.tid = (uint16_t)SMB_FD_TID(fd);
 
     SMB_MSG_INIT_PKT(req);
     req.wct        = 3;
@@ -181,7 +181,7 @@ ssize_t   smb_fread(smb_session *s, smb_fd fd, void *buf, size_t buf_size)
     req_msg = smb_message_new(SMB_CMD_READ);
     if (!req_msg)
         return (-1);
-    req_msg->packet->header.tid = file->tid;
+    req_msg->packet->header.tid = (uint16_t)file->tid;
 
     max_read = 0xffff;
     max_read = max_read < buf_size ? max_read : buf_size;

--- a/src/smb_trans2.c
+++ b/src/smb_trans2.c
@@ -190,7 +190,7 @@ static smb_message  *smb_trans2_find_first (smb_session *s, smb_tid tid, const c
         free(utf_pattern);
         return (NULL);
     }
-    msg->packet->header.tid = tid;
+    msg->packet->header.tid = (uint16_t)tid;
 
     SMB_MSG_INIT_PKT(tr2);
     tr2.wct                = 15;
@@ -257,7 +257,7 @@ static smb_message  *smb_trans2_find_next (smb_session *s, smb_tid tid, uint16_t
     }
 
     msg_find_next2 = smb_message_new(SMB_CMD_TRANS2);
-    msg_find_next2->packet->header.tid = tid;
+    msg_find_next2->packet->header.tid = (uint16_t)tid;
 
     SMB_MSG_INIT_PKT(tr2_find_next2);
     tr2_find_next2.wct                = 0x0f;
@@ -418,7 +418,7 @@ smb_file  *smb_fstat(smb_session *s, smb_tid tid, const char *path)
         free(utf_path);
         return (0);
     }
-    msg->packet->header.tid = tid;
+    msg->packet->header.tid = (uint16_t)tid;
 
     SMB_MSG_INIT_PKT(tr2);
     tr2.wct                = 15;


### PR DESCRIPTION
When we were connecting to a share, if the server was returning a "tid" of 0, the value was considered as wrong and no action was possible.
Possible fix for #43 