### PR TITLE
fix smb_tree_connect invalid return value in documentation and sample app

### DIFF
--- a/bin/dsm.c
+++ b/bin/dsm.c
@@ -192,7 +192,7 @@ int main(int ac, char **av)
 
 
   smb_tid test = smb_tree_connect(session, share);
-  if (test)
+  if (test != -1)
     fprintf(stderr, "Connected to %s share\n", share);
   else
   {

--- a/include/bdsm/smb_share.h
+++ b/include/bdsm/smb_share.h
@@ -89,7 +89,7 @@ void            smb_share_list_destroy(smb_share_list list);
  * @param name The share name @see smb_share_list
  *
  * @return An opaque value representing an open share (like a file descriptor)
- * or 0 if there was an error
+ * or -1 if there was an error
  */
 smb_tid         smb_tree_connect(smb_session *s, const char *name);
 


### PR DESCRIPTION
header (documentation) for smb_tree_connect and sample app were not in line with change in tid invalid value