### PR TITLE
Fix uid issue & session state update

### DIFF
--- a/src/smb_spnego.c
+++ b/src/smb_spnego.c
@@ -317,6 +317,7 @@ static int      auth(smb_session *s, const char *domain, const char *user,
             s->guest = true;
 
         s->srv.uid  = resp.packet->header.uid;
+        s->state    = SMB_STATE_SESSION_OK;
 
         return (1);
     }

--- a/src/smb_spnego.c
+++ b/src/smb_spnego.c
@@ -316,6 +316,8 @@ static int      auth(smb_session *s, const char *domain, const char *user,
         if (r->action & 0x0001)
             s->guest = true;
 
+        s->srv.uid  = resp.packet->header.uid;
+
         return (1);
     }
 


### PR DESCRIPTION
This commit fixes the case were the server is changing the user id in the latest response of spnego authentication. I have this for a server configured to accept any user/password but considering user as guest in any case (a kind of public server).
It also fixes session state that was not updated to "SMB_STATE_SESSION_OK" when authentication was ok.