### PR TITLE
fix shares listing for macos x which was broken by file upload commit

### DIFF
--- a/src/smb_share.c
+++ b/src/smb_share.c
@@ -243,7 +243,7 @@ size_t          smb_share_get_list(smb_session *s, char ***list)
     if (ipc_tid == -1)
         return 0;
 
-    srvscv_fd = smb_fopen(s, ipc_tid, "\\srvsvc", SMB_MOD_RW);
+    srvscv_fd = smb_fopen(s, ipc_tid, "\\srvsvc", SMB_MOD_READ | SMB_MOD_WRITE);
     if (!srvscv_fd)
         return 0;
 


### PR DESCRIPTION
smb_fopen is used in the messy and impossible to understand smb_share_get_list function with SMB_MOD_RW. Changes done in smb_fopen function for file writing is breaking smb_share_get_list for some servers (only found problem when connecting to a MacOs X server but some other servers may be impacted). This commit is fixing this issue with connection to MacOS X servers.