### PR TITLE
Fix for checking if a session is logged in.

### DIFF
--- a/src/smb_session.c
+++ b/src/smb_session.c
@@ -313,7 +313,7 @@ int             smb_session_is_guest(smb_session *s)
     assert(s != NULL);
 
     // We're not logged in yet.
-    if (s->logged)
+    if (s->logged != true)
         return -1;
 
     // We're logged in as guest


### PR DESCRIPTION
I was refactoring my libdsm wrapper library and found I needed an alternate way to check if a session had successfully connected now that `smb_sesstion_state()` has been removed.

`smb_session_is_guest()` seems a good alternative as a replacement, however I noticed its return values were somewhat inconsistent with its documentation. At the moment, if the session's `logged` value is true, the function is returning -1.

I'm assuming that's a bug, and so this PR hopefully fixes that function. :)