### PR TITLE
include sys/socket.h for socket() and SOCK_DGRAM

### DIFF
--- a/src/netbios_ns.c
+++ b/src/netbios_ns.c
@@ -52,6 +52,8 @@
 #ifdef _WIN32
 # include <winsock2.h>
 # include <ws2tcpip.h>
+#else
+# include <sys/socket.h>
 #endif
 
 #include <bdsm/netbios_ns.h>

--- a/src/netbios_session.c
+++ b/src/netbios_session.c
@@ -39,6 +39,9 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifndef _WIN32
+#include <sys/socket.h>
+#else
 
 #include "bdsm_debug.h"
 #include "netbios_session.h"


### PR DESCRIPTION
I've noticed this while building vlc-android. On GNU/Linux ```sys/socket.h``` is indirectly included by ```netinet/in.h```, which is included by ```arpa/inet.h```. But this is not always the case, e.g. android-ndk up through platform-19.