### PR TITLE
add smb_stat_list_next()

### DIFF
--- a/include/bdsm/smb_stat.h
+++ b/include/bdsm/smb_stat.h
@@ -109,6 +109,7 @@ void            smb_stat_destroy(smb_stat stat);
  */
 size_t            smb_stat_list_count(smb_stat_list list);
 
+smb_stat        smb_stat_list_next(smb_stat_list stat);
 /**
  * @brief Get the element at the given position.
  *

--- a/src/libdsm.sym
+++ b/src/libdsm.sym
@@ -36,6 +36,7 @@ smb_stat_destroy
 smb_stat_fd
 smb_stat_get
 smb_stat_list_at
+smb_stat_list_next
 smb_stat_list_count
 smb_stat_list_destroy
 smb_stat_name

--- a/src/smb_stat.c
+++ b/src/smb_stat.c
@@ -72,6 +72,11 @@ void            smb_stat_list_destroy(smb_stat_list list)
     }
 }
 
+smb_stat        smb_stat_list_next(smb_stat_list list)
+{
+    return list->next;
+}
+
 smb_stat        smb_stat_list_at(smb_stat_list list, size_t index)
 {
     size_t          pos = 0;


### PR DESCRIPTION
Traversal a huge directory with smb_stat_list_at() is too slow.
Add a new function smb_stat_list_next() to reduce time to O(N).

Signed-off-by: Zhai Zhaoxuan <zhaizhaoxuan@xiaomi.com>