### PR TITLE
smb_fstat: check malformed packet

### DIFF
--- a/src/smb_dir.c
+++ b/src/smb_dir.c
@@ -42,6 +42,7 @@
 #include "smb_fd.h"
 #include "smb_utils.h"
 #include "smb_dir.h"
+#include "bdsm_debug.h"
 
 int smb_directory_rm(smb_session *s, smb_tid tid, const char *path)
 {
@@ -83,6 +84,12 @@ int smb_directory_rm(smb_session *s, smb_tid tid, const char *path)
 
     if (!smb_session_check_nt_status(s, &resp_msg))
         return DSM_ERROR_NT;
+
+    if (resp_msg.payload_size < sizeof(smb_directory_rm_resp))
+    {
+        BDSM_dbg("[smb_directory_rm]Malformed message.\n");
+        return DSM_ERROR_NETWORK;
+    }
 
     resp = (smb_directory_rm_resp *)resp_msg.packet->payload;
     if ((resp->wct != 0) || (resp->bct != 0))
@@ -131,6 +138,12 @@ int smb_directory_create(smb_session *s, smb_tid tid, const char *path)
 
     if (!smb_session_check_nt_status(s, &resp_msg))
         return DSM_ERROR_NT;
+
+    if (resp_msg.payload_size < sizeof(smb_directory_mk_resp))
+    {
+        BDSM_dbg("[smb_directory_create]Malformed message %s\n", path);
+        return DSM_ERROR_NETWORK;
+    }
 
     resp = (smb_directory_mk_resp *)resp_msg.packet->payload;
     if ((resp->wct != 0) || (resp->bct != 0))

--- a/src/smb_file.c
+++ b/src/smb_file.c
@@ -42,6 +42,7 @@
 #include "smb_fd.h"
 #include "smb_utils.h"
 #include "smb_file.h"
+#include "bdsm_debug.h"
 
 int         smb_fopen(smb_session *s, smb_tid tid, const char *path,
                       uint32_t o_flags, smb_fd *fd)
@@ -114,6 +115,12 @@ int         smb_fopen(smb_session *s, smb_tid tid, const char *path,
         return DSM_ERROR_NETWORK;
     if (!smb_session_check_nt_status(s, &resp_msg))
         return DSM_ERROR_NT;
+
+    if (resp_msg.payload_size < sizeof(smb_create_resp))
+    {
+        BDSM_dbg("[smb_fopen]Malformed message.\n");
+        return DSM_ERROR_NETWORK;
+    }
 
     resp = (smb_create_resp *)resp_msg.packet->payload;
     file = calloc(1, sizeof(smb_file));
@@ -222,7 +229,21 @@ ssize_t   smb_fread(smb_session *s, smb_fd fd, void *buf, size_t buf_size)
     if (!smb_session_check_nt_status(s, &resp_msg))
         return -1;
 
+    if (resp_msg.payload_size < sizeof(smb_read_resp))
+    {
+        BDSM_dbg("[smb_fread]Malformed message.\n");
+        return DSM_ERROR_NETWORK;
+    }
+
     resp = (smb_read_resp *)resp_msg.packet->payload;
+
+    if (resp_msg.packet->payload + resp_msg.payload_size <
+        (uint8_t *)resp_msg.packet + resp->data_offset + resp->data_len)
+    {
+        BDSM_dbg("[smb_fread]Malformed message.\n");
+        return DSM_ERROR_NETWORK;
+    }
+
     if (buf)
         memcpy(buf, (char *)resp_msg.packet + resp->data_offset, resp->data_len);
     smb_fseek(s, fd, resp->data_len, SEEK_CUR);
@@ -278,6 +299,12 @@ ssize_t   smb_fwrite(smb_session *s, smb_fd fd, void *buf, size_t buf_size)
         return -1;
     if (!smb_session_check_nt_status(s, &resp_msg))
         return -1;
+
+    if (resp_msg.payload_size < sizeof(smb_write_resp))
+    {
+        BDSM_dbg("[smb_fwrite]Malformed message.\n");
+        return DSM_ERROR_NETWORK;
+    }
 
     resp = (smb_write_resp *)resp_msg.packet->payload;
 
@@ -345,6 +372,12 @@ int  smb_file_rm(smb_session *s, smb_tid tid, const char *path)
     if (!smb_session_check_nt_status(s, &resp_msg))
         return DSM_ERROR_NT;
 
+    if (resp_msg.payload_size < sizeof(smb_file_rm_resp))
+    {
+        BDSM_dbg("[smb_file_rm]Malformed message.\n");
+        return DSM_ERROR_NETWORK;
+    }
+
     resp = (smb_file_rm_resp *)resp_msg.packet->payload;
     if ((resp->wct != 0) || (resp->bct != 0))
         return DSM_ERROR_NETWORK;
@@ -406,6 +439,12 @@ int       smb_file_mv(smb_session *s, smb_tid tid, const char *old_path, const c
 
     if (!smb_session_check_nt_status(s, &resp_msg))
         return DSM_ERROR_NT;
+
+    if (resp_msg.payload_size < sizeof(smb_file_mv_resp))
+    {
+        BDSM_dbg("[smb_file_mv]Malformed message.\n");
+        return DSM_ERROR_NETWORK;
+    }
 
     resp = (smb_file_mv_resp *)resp_msg.packet->payload;
     if ((resp->wct != 0) || (resp->bct != 0))

--- a/src/smb_session.c
+++ b/src/smb_session.c
@@ -188,6 +188,12 @@ static int        smb_negotiate(smb_session *s)
     if (!smb_session_recv_msg(s, &answer))
         return DSM_ERROR_NETWORK;
 
+    if (answer.payload_size < sizeof(smb_nego_resp))
+    {
+        BDSM_dbg("[smb_negotiate]Malformed message\n");
+        return DSM_ERROR_NETWORK;
+    }
+
     nego = (smb_nego_resp *)answer.packet->payload;
     if (!smb_session_check_nt_status(s, &answer))
         return DSM_ERROR_NT;
@@ -272,6 +278,12 @@ static int        smb_session_login_ntlm(smb_session *s, const char *domain,
     if (smb_session_recv_msg(s, &answer) == 0)
     {
         BDSM_dbg("Unable to get Session Setup AndX reply\n");
+        return DSM_ERROR_NETWORK;
+    }
+
+    if (answer.payload_size < sizeof(smb_session_resp))
+    {
+        BDSM_dbg("[smb_negotiate]Malformed message\n");
         return DSM_ERROR_NETWORK;
     }
 

--- a/src/smb_share.c
+++ b/src/smb_share.c
@@ -98,6 +98,12 @@ int smb_tree_connect(smb_session *s, const char *name, smb_tid *tid)
     if (!smb_session_check_nt_status(s, &resp_msg))
         return DSM_ERROR_NT;
 
+    if (resp_msg.payload_size < sizeof(smb_tree_connect_resp))
+    {
+        BDSM_dbg("[smb_tree_connect]Malformed message\n");
+        return DSM_ERROR_NETWORK;
+    }
+
     resp  = (smb_tree_connect_resp *)resp_msg.packet->payload;
     share = calloc(1, sizeof(smb_share));
     if (!share)
@@ -147,6 +153,12 @@ int           smb_tree_disconnect(smb_session *s, smb_tid tid)
     if (!smb_session_check_nt_status(s, &resp_msg))
         return DSM_ERROR_NT;
 
+    if (resp_msg.payload_size < sizeof(smb_tree_disconnect_resp))
+    {
+        BDSM_dbg("[smb_tree_disconnect]Malformed message\n");
+        return DSM_ERROR_NETWORK;
+    }
+
     resp  = (smb_tree_disconnect_resp *)resp_msg.packet->payload;
     if ((resp->wct != 0) || (resp->bct != 0))
         return DSM_ERROR_NETWORK;
@@ -179,8 +191,20 @@ static ssize_t  smb_share_parse_enum(smb_message *msg, char ***list)
     {
         uint32_t name_len, com_len;
 
+        if (data + sizeof(uint32_t) > eod)
+        {
+            BDSM_dbg("[smb_share_parse_enum]Malformed message\n");
+            break;
+        }
+
         name_len = *((uint32_t *)data);   // Read 'Max Count', make it a multiple of 2
         data    += 3 * sizeof(uint32_t);  // Move pointer to beginning of Name.
+
+        if (data +  sizeof(uint32_t) + name_len * 2 + sizeof(uint32_t) > eod)
+        {
+            BDSM_dbg("[smb_share_parse_enum]Malformed message\n");
+            break;
+        }
 
         smb_from_utf16((const char *)data, name_len * 2, (*list) + i);
 
@@ -317,6 +341,13 @@ int             smb_share_get_list(smb_session *s, smb_share_list *list, size_t 
 
     // Is the server throwing pile of shit back at me ?
     res = smb_session_recv_msg(s, &resp);
+    if (resp.payload_size < 71)
+    {
+        BDSM_dbg("[smb_share_get_list]Malformed message\n");
+        ret = DSM_ERROR_NETWORK;
+        goto error;
+    }
+
     if (!res || resp.packet->payload[68])
     {
         BDSM_dbg("Bind call failed: 0x%hhx (reason = 0x%hhx)\n",
@@ -408,6 +439,13 @@ int             smb_share_get_list(smb_session *s, smb_share_list *list, size_t 
 
     // Is the server throwing pile of shit back at me ?
     res = smb_session_recv_msg(s, &resp);
+    if (resp.payload_size < 4)
+    {
+        BDSM_dbg("[smb_share_get_list]Malformed message\n");
+        ret = DSM_ERROR_NETWORK;
+        goto error;
+    }
+
     if (!res && (uint32_t)resp.packet->payload[resp.payload_size - 4])
     {
         BDSM_dbg("NetShareEnumAll call failed.\n");

--- a/src/smb_trans2.c
+++ b/src/smb_trans2.c
@@ -477,8 +477,21 @@ smb_file  *smb_fstat(smb_session *s, smb_tid tid, const char *path)
         return NULL;
     }
 
+    if (reply.payload_size < sizeof(smb_tr2_path_info))
+    {
+        BDSM_dbg("[smb_fstat]Malformed message %s\n", path);
+        return NULL;
+    }
+
     tr2_resp  = (smb_trans2_resp *)reply.packet->payload;
     info      = (smb_tr2_path_info *)(tr2_resp->payload + 4); //+4 is padding
+
+    if (info->name + info->name_len > reply.packet->payload + reply.payload_size)
+    {
+        BDSM_dbg("[smb_fstat]Malformed message %s\n", path);
+        return NULL;
+    }
+
     file      = calloc(1, sizeof(smb_file));
     if (!file)
         return NULL;


### PR DESCRIPTION
try fix #117 

A lot of functions use the server data without check boundary, so I do not guarantee that all code are fixed.

I think we should access the payload as a stream instead of use it a pointer to read data directly.