### PR TITLE
Fix too small buffer for ASN1 response token.

### DIFF
--- a/src/smb_spnego.c
+++ b/src/smb_spnego.c
@@ -171,12 +171,12 @@ error:
 static int      challenge(smb_session *s)
 {
     char                  err_desc[ASN1_MAX_ERROR_DESCRIPTION_SIZE];
-    char                  resp_token[256];
+    char                  resp_token[512];
     smb_message           msg;
     smb_session_xsec_resp *resp;
     smb_ntlmssp_challenge *challenge;
     ASN1_TYPE             token;
-    int                   res, resp_token_size = 256;
+    int                   res, resp_token_size = sizeof(resp_token);
 
     assert(s != NULL);
 


### PR DESCRIPTION
* After having done a server upgrade to some newer version of samba,
  smb_session_login_spnego() consistently failed. The reason was
  that smb_spnego::challenge() invokes asn1_read_value() with a
  buffer of size 256 bytes, but that function for some reason
  requires a buffer of 258 bytes in size. Fix this the simple
  way by increasing the on-stack buffer to 512 bytes.