### PR TITLE
pkg-config: don't hardcode -liconv.

### DIFF
--- a/libdsm.pc.in
+++ b/libdsm.pc.in
@@ -8,4 +8,4 @@ Description: Minimalist and read-only smb client library
 Version: @BDSM_PACKAGE_VERSION@
 Cflags: -I${includedir} @PTHREAD_CFLAGS@
 Libs: -L${libdir} -ldsm
-Libs.private: -liconv -ltasn1 @PTHREAD_LIBS@ @BDSM_LIB_LOG@ @SOCKET_LIBS@
+Libs.private: @LIBICONV@ -ltasn1 @PTHREAD_LIBS@ @BDSM_LIB_LOG@ @SOCKET_LIBS@


### PR DESCRIPTION
It's not available everywhere.