### PR TITLE
Fixed segmentation fault

### DIFF
--- a/src/netbios_ns.c
+++ b/src/netbios_ns.c
@@ -280,6 +280,8 @@ static void netbios_ns_broadcast_packet(netbios_ns* ns, netbios_query* q)
         if (a->ifa_addr->sa_family != PF_INET)
             continue;
         struct sockaddr_in* sin = (struct sockaddr_in*)a->ifa_broadaddr;
+        if (!sin)
+            continue;
 
         uint32_t ip = sin->sin_addr.s_addr;
         if (netbios_ns_send_packet(ns, q, ip) == -1)


### PR DESCRIPTION
Hi,
there has been a segmentation fault on my Windows machine, because the ifa->broadaddr is null on a interface. This check fixes this.

Roman