### PR TITLE
build: fix build with android NDK 17

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,9 +107,9 @@ AC_CHECK_DECLS([CLOCK_MONOTONIC],,,[
 AC_REPLACE_FUNCS([strlcpy])
 AC_REPLACE_FUNCS([strndup])
 AC_REPLACE_FUNCS([clock_gettime])
-AC_CHECK_FUNCS([pipe _pipe getifaddrs])
+AC_CHECK_FUNCS([pipe _pipe getifaddrs nl_langinfo])
 
-AC_CHECK_HEADERS([bsd/string.h langinfo.h alloca.h sys/queue.h arpa/inet.h sys/socket.h sys/time.h ifaddrs.h])
+AC_CHECK_HEADERS([bsd/string.h alloca.h sys/queue.h arpa/inet.h sys/socket.h sys/time.h ifaddrs.h])
 
 ## Configure random device path
 AC_ARG_WITH([urandom], 

--- a/src/smb_utils.c
+++ b/src/smb_utils.c
@@ -40,7 +40,7 @@
 #include <string.h>
 #include <errno.h>
 
-#if HAVE_LANGINFO_H && !defined( __APPLE__ )
+#if HAVE_NL_LANGINFO && !defined( __APPLE__ )
 # include <langinfo.h>
 #endif
 
@@ -51,7 +51,7 @@ static const char *current_encoding()
 {
 #if defined( __APPLE__ )
     return "UTF8";
-#elif !HAVE_LANGINFO_H
+#elif !HAVE_NL_LANGINFO
     return "UTF-8";
 #else
     static int locale_set = 0;


### PR DESCRIPTION
The android NDK 17 provides the header, but not necessarily the
nl_langinfo function.