### PR TITLE
Fix buffer reallocation size in `netbios_session_packet_append`.

### DIFF
--- a/src/netbios_session.c
+++ b/src/netbios_session.c
@@ -210,7 +210,7 @@ int               netbios_session_packet_append(netbios_session *s,
     assert(s && s->packet);
 
     if (s->packet_payload_size - s->packet_cursor < size)
-        if (!session_buffer_realloc(s, size + s->packet_cursor))
+        if (!session_buffer_realloc(s, size + s->packet_cursor + sizeof(netbios_session_packet)))
             return 0;
 
     start = ((char *)&s->packet->payload) + s->packet_cursor;


### PR DESCRIPTION
This fixes a crash in `smb_fwrite` under iOS.

Seems to relate to #85.