### PR TITLE
add smb_session_abort()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+Changes between 0.3.1 and 0.3.3:
+--------------------------------
+  * Switch to meson buildsystem
+  * add smb_session_abort() and netbios_ns_abort() that allow interrupting any
+    I/O operations
+
+
 Changes between 0.3.0 and 0.3.1:
 --------------------------------
 

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -65,20 +65,6 @@ char *strndup(const char *str, size_t n);
 # include "queue.h"
 #endif
 
-#if !defined(HAVE_PIPE) && defined(HAVE__PIPE)
-# ifdef _WIN32
-#  include <winapifamily.h>
-# endif
-# if !defined(_WIN32) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-#  include <fcntl.h>
-#  define HAVE_PIPE
-static inline int pipe(int fds[2])
-{
-    return _pipe(fds, 32768, O_NOINHERIT | O_BINARY);
-}
-#endif
-#endif
-
 #ifndef _WIN32
 #define closesocket(fd) close(fd)
 #endif

--- a/include/bdsm.h
+++ b/include/bdsm.h
@@ -31,9 +31,9 @@
 #ifndef __BDSM_H_
 #define __BDSM_H_
 
-#define BDSM_VERSION_CURRENT  4
+#define BDSM_VERSION_CURRENT  5
 #define BDSM_VERSION_REVISION 0
-#define BDSM_VERSION_AGE      1
+#define BDSM_VERSION_AGE      0
 
 #include "bdsm/netbios_ns.h"
 #include "bdsm/netbios_defs.h"

--- a/include/bdsm/netbios_ns.h
+++ b/include/bdsm/netbios_ns.h
@@ -96,6 +96,17 @@ BDSM_EXPORT
 void          netbios_ns_destroy(netbios_ns *ns);
 
 /**
+ * @brief Interrupt any I/O netbios_ns functions (netbios_ns_resolve,
+ * netbios_ns_inverse...)
+ * @details This function can be called from any threads. The ns object is
+ * unusable after this call, only netbios_ns_destroy() should be called after.
+ *
+ * @param ns the netbios name service object to abort
+ */
+BDSM_EXPORT
+void          netbios_ns_abort(netbios_ns *ns);
+
+/**
  * @brief Resolve a Netbios name
  * @details This function tries to resolves the given NetBIOS name with the
  * given type on the LAN, using broadcast queries. No WINS server is called.

--- a/include/bdsm/smb_session.h
+++ b/include/bdsm/smb_session.h
@@ -60,6 +60,17 @@ BDSM_EXPORT
 void            smb_session_destroy(smb_session *s);
 
 /**
+ * @brief Interrupt any I/O smb_session functions (smb_session_connect,
+ * smb_fread...)
+ * @details This function can be called from any threads. The session is
+ * unusable after this call, only smb_session_destroy() should be called after.
+ *
+ * @param s The session to abort
+ */
+BDSM_EXPORT
+void            smb_session_abort(smb_session *s);
+
+/**
  * @brief Set the credentials for this session.
  * @details Any of the params except s can be NULL.
  *

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libdsm', ['c'],
-    version: '0.3.2',
+    version: '0.3.3',
     license: ['LGPL2'],
     default_options: ['c_std=c11',
                       'warning_level=2',
@@ -8,7 +8,7 @@ project('libdsm', ['c'],
     meson_version: '>= 0.53.0')
 
 #Soname
-dsm_soname_version = '3.1.0'
+dsm_soname_version = '3.2.0'
 if host_machine.system() == 'windows'
   dsm_soversion = ''
 else

--- a/src/netbios_ns.c
+++ b/src/netbios_ns.c
@@ -681,13 +681,13 @@ netbios_ns  *netbios_ns_new()
     if (!ns)
         return NULL;
 
-#ifdef NS_ABORT_USE_PIPE
-    // Don't initialize this in ns_open_abort_pipe, as it would lead to
-    // fd 0 to be closed (twice) in case of ns_open_socket error
-    ns->abort_pipe[0] = ns->abort_pipe[1] = -1;
-#endif
+    if (ns_open_abort_pipe(ns) == -1)
+    {
+        free(ns);
+        return NULL;
+    }
 
-    if (!ns_open_socket(ns) || ns_open_abort_pipe(ns) == -1)
+    if (!ns_open_socket(ns))
     {
         netbios_ns_destroy(ns);
         return NULL;

--- a/src/netbios_ns.c
+++ b/src/netbios_ns.c
@@ -687,13 +687,14 @@ netbios_ns  *netbios_ns_new()
         return NULL;
     }
 
+    TAILQ_INIT(&ns->entry_queue);
+
     if (!ns_open_socket(ns))
     {
         netbios_ns_destroy(ns);
         return NULL;
     }
 
-    TAILQ_INIT(&ns->entry_queue);
     ns->last_trn_id   = rand();
 
     return ns;

--- a/src/netbios_ns.c
+++ b/src/netbios_ns.c
@@ -661,6 +661,11 @@ void          netbios_ns_destroy(netbios_ns *ns)
     free(ns);
 }
 
+void          netbios_ns_abort(netbios_ns *ns)
+{
+    netbios_abort_ctx_abort(&ns->abort_ctx);
+}
+
 int      netbios_ns_resolve(netbios_ns *ns, const char *name, char type, uint32_t *addr)
 {
     netbios_ns_entry    *cached;

--- a/src/netbios_ns.c
+++ b/src/netbios_ns.c
@@ -223,7 +223,8 @@ static bool   netbios_ns_is_aborted(netbios_ns *ns)
 static void netbios_ns_abort(netbios_ns *ns)
 {
     uint8_t buf = '\0';
-    write(ns->abort_pipe[1], &buf, sizeof(uint8_t));
+    ssize_t ret = write(ns->abort_pipe[1], &buf, sizeof(uint8_t));
+    (void) ret;
 }
 
 #else

--- a/src/netbios_ns.c
+++ b/src/netbios_ns.c
@@ -193,8 +193,8 @@ static void   ns_close_abort_pipe(netbios_ns *ns)
 {
     if (ns->abort_pipe[0] != -1 && ns->abort_pipe[1] != -1)
     {
-        closesocket(ns->abort_pipe[0]);
-        closesocket(ns->abort_pipe[1]);
+        close(ns->abort_pipe[0]);
+        close(ns->abort_pipe[1]);
         ns->abort_pipe[0] = ns->abort_pipe[1] = -1;
     }
 }

--- a/src/netbios_ns.c
+++ b/src/netbios_ns.c
@@ -139,6 +139,8 @@ static int    ns_open_socket(netbios_ns *ns)
     if ((ns->socket = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
         goto error;
 
+    fcntl(ns->socket, F_SETFL, fcntl(ns->socket, F_GETFL, 0) | O_NONBLOCK);
+
     sock_opt = 1;
     if (setsockopt(ns->socket, SOL_SOCKET, SO_BROADCAST,
                    (void *)&sock_opt, sizeof(sock_opt)) < 0)

--- a/src/netbios_session.c
+++ b/src/netbios_session.c
@@ -259,6 +259,16 @@ int               netbios_session_packet_send(netbios_session *s)
     return sent;
 }
 
+static ssize_t netbios_session_recv(netbios_session *s, void *buf, size_t len)
+{
+    ssize_t res = recv(s->socket, buf, len, 0);
+
+    if (res <= 0)
+        BDSM_perror("netbios_session_packet_recv: ");
+
+    return res;
+}
+
 static ssize_t    netbios_session_get_next_packet(netbios_session *s)
 {
     ssize_t         res;
@@ -272,12 +282,9 @@ static ssize_t    netbios_session_get_next_packet(netbios_session *s)
     sofar = 0;
     while (sofar < total)
     {
-        res = recv(s->socket, (uint8_t *)(s->packet) + sofar, total - sofar, 0);
+        res = netbios_session_recv(s, (uint8_t *)(s->packet) + sofar, total - sofar);
         if (res <= 0)
-        {
-            BDSM_perror("netbios_session_packet_recv: ");
             return -1;
-        }
         sofar += res;
     }
 
@@ -293,15 +300,12 @@ static ssize_t    netbios_session_get_next_packet(netbios_session *s)
 
     while (sofar < total)
     {
-        res = recv(s->socket, (uint8_t *)(s->packet) + sizeof(netbios_session_packet)
-                   + sofar, total - sofar, 0);
+        res = netbios_session_recv(s, (uint8_t *)(s->packet) + sizeof(netbios_session_packet)
+                                   + sofar, total - sofar);
         //BDSM_dbg("Total = %ld, sofar = %ld, res = %ld\n", total, sofar, res);
 
         if (res <= 0)
-        {
-            BDSM_perror("netbios_session_packet_recv: ");
             return -1;
-        }
         sofar += res;
     }
 

--- a/src/netbios_session.c
+++ b/src/netbios_session.c
@@ -117,12 +117,22 @@ netbios_session *netbios_session_new(size_t buf_size)
     return session;
 }
 
+void              netbios_session_disconnect(netbios_session *s)
+{
+    if (!s)
+        return;
+
+    if (s->socket != -1)
+    {
+        closesocket(s->socket);
+        s->socket = -1;
+    }
+}
+
 void              netbios_session_destroy(netbios_session *s)
 {
     if (!s)
         return;
-    if (s->socket != -1)
-        closesocket(s->socket);
 
     free(s->packet);
     free(s);

--- a/src/netbios_session.h
+++ b/src/netbios_session.h
@@ -41,6 +41,7 @@
 #endif
 
 #include "netbios_defs.h"
+#include "netbios_utils.h"
 
 #define NETBIOS_SESSION_NEW         0
 #define NETBIOS_SESSION_CONNECTING  1
@@ -50,6 +51,8 @@
 
 typedef struct              netbios_session_s
 {
+    struct netbios_abort_ctx    abort_ctx;
+
     // The address of the remote peer;
     struct sockaddr_in          remote_addr;
     // The socket of the TCP connection to the HOST'
@@ -68,6 +71,7 @@ typedef struct              netbios_session_s
 // Return NULL if unable to open socket/connect
 netbios_session   *netbios_session_new(size_t buf_size);
 void              netbios_session_destroy(netbios_session *);
+void              netbios_session_abort(netbios_session *);
 int               netbios_session_connect(uint32_t ip,
         netbios_session *s,
         const char *name,

--- a/src/netbios_session.h
+++ b/src/netbios_session.h
@@ -72,6 +72,7 @@ int               netbios_session_connect(uint32_t ip,
         netbios_session *s,
         const char *name,
         int direct_tcp);
+void              netbios_session_disconnect(netbios_session *);
 void              netbios_session_packet_init(netbios_session *s);
 int               netbios_session_packet_append(netbios_session *s,
         const char *data, size_t size);

--- a/src/netbios_utils.h
+++ b/src/netbios_utils.h
@@ -32,6 +32,7 @@
 #define _NETBIOS_UTILS_H_
 
 #include "netbios_defs.h"
+#include <stdbool.h>
 
 void  netbios_name_level1_encode(const char *name, char *encoded_name,
                                  unsigned type);
@@ -42,5 +43,25 @@ char  *netbios_name_encode(const char *name, char *domain,
                            unsigned type);
 int   netbios_name_decode(const char *encoded_name,
                           char *name, char **domain);
+
+#if defined (HAVE_PIPE) && !defined (_WIN32)
+#define NS_ABORT_USE_PIPE
+#else
+#include <stdatomic.h>
+#endif
+
+struct netbios_abort_ctx
+{
+#ifdef NS_ABORT_USE_PIPE
+    int                 pipe[2];
+#else
+    atomic_bool         aborted;
+#endif
+};
+
+int netbios_abort_ctx_init(struct netbios_abort_ctx *ctx);
+void netbios_abort_ctx_destroy(struct netbios_abort_ctx *ctx);
+bool netbios_abort_ctx_is_aborted(struct netbios_abort_ctx *ctx);
+void netbios_abort_ctx_abort(struct netbios_abort_ctx *ctx);
 
 #endif

--- a/src/smb_session.c
+++ b/src/smb_session.c
@@ -44,6 +44,7 @@
 #include "smb_ntlm.h"
 #include "smb_spnego.h"
 #include "smb_transport.h"
+#include "netbios_utils.h"
 
 static int        smb_negotiate(smb_session *s);
 
@@ -101,7 +102,14 @@ void            smb_session_destroy(smb_session *s)
     free(s->creds.domain);
     free(s->creds.login);
     free(s->creds.password);
+
     free(s);
+}
+
+void            smb_session_abort(smb_session *s)
+{
+    assert(s != NULL && s->transport.session != NULL);
+    smb_transport_abort_session(s->transport.session);
 }
 
 void            smb_session_set_creds(smb_session *s, const char *domain,

--- a/src/smb_transport.c
+++ b/src/smb_transport.c
@@ -63,6 +63,11 @@ void              smb_transport_destroy_session(void *s)
     netbios_session_destroy(s);
 }
 
+void              smb_transport_abort_session(void *s)
+{
+    netbios_session_abort(s);
+}
+
 void              smb_transport_nbt(smb_transport *tr)
 {
     assert(tr != NULL);

--- a/src/smb_transport.c
+++ b/src/smb_transport.c
@@ -53,14 +53,23 @@ int               transport_connect_tcp(uint32_t ip,
     return netbios_session_connect(ip, s, name, 1);
 }
 
+void *            smb_transport_new_session(size_t buf_size)
+{
+    return netbios_session_new(buf_size);
+}
+
+void              smb_transport_destroy_session(void *s)
+{
+    netbios_session_destroy(s);
+}
+
 void              smb_transport_nbt(smb_transport *tr)
 {
     assert(tr != NULL);
 
     // Sorry for the dirty cast.
-    tr->new           = (void *)netbios_session_new;
     tr->connect       = (void *)transport_connect_nbt;
-    tr->destroy       = (void *)netbios_session_destroy;
+    tr->disconnect    = (void *)netbios_session_disconnect;
     tr->pkt_init      = (void *)netbios_session_packet_init;
     tr->pkt_append    = (void *)netbios_session_packet_append;
     tr->send          = (void *)netbios_session_packet_send;
@@ -71,9 +80,8 @@ void              smb_transport_tcp(smb_transport *tr)
 {
     assert(tr != NULL);
 
-    tr->new           = (void *)netbios_session_new;
     tr->connect       = (void *)transport_connect_tcp;
-    tr->destroy       = (void *)netbios_session_destroy;
+    tr->disconnect    = (void *)netbios_session_disconnect;
     tr->pkt_init      = (void *)netbios_session_packet_init;
     tr->pkt_append    = (void *)netbios_session_packet_append;
     tr->send          = (void *)netbios_session_packet_send;

--- a/src/smb_transport.c
+++ b/src/smb_transport.c
@@ -39,14 +39,14 @@
 
 // XXX: This can be simplified, since we have only one function that differs
 
-int               transport_connect_nbt(uint32_t ip,
+static int        transport_connect_nbt(uint32_t ip,
                                         netbios_session *s,
                                         const char *name)
 {
     return netbios_session_connect(ip, s, name, 0);
 }
 
-int               transport_connect_tcp(uint32_t ip,
+static int        transport_connect_tcp(uint32_t ip,
                                         netbios_session *s,
                                         const char *name)
 {

--- a/src/smb_transport.h
+++ b/src/smb_transport.h
@@ -36,6 +36,7 @@
 
 void *            smb_transport_new_session(size_t buf_size);
 void              smb_transport_destroy_session(void *s);
+void              smb_transport_abort_session(void *);
 
 /**
  * @internal

--- a/src/smb_transport.h
+++ b/src/smb_transport.h
@@ -33,6 +33,10 @@
 
 #include "smb_types.h"
 
+
+void *            smb_transport_new_session(size_t buf_size);
+void              smb_transport_destroy_session(void *s);
+
 /**
  * @internal
  * @brief Fill the smb_transport structure with the fun pointers for using

--- a/src/smb_types.h
+++ b/src/smb_types.h
@@ -89,9 +89,8 @@ typedef struct smb_transport smb_transport;
 struct smb_transport
 {
     void              *session;
-    void              *(*new)(size_t buf_size);
     int               (*connect)(uint32_t ip, void *s, const char *name);
-    void              (*destroy)(void *s);
+    void              (*disconnect)(void *s);
     void              (*pkt_init)(void *s);
     int               (*pkt_append)(void *s, void *data, size_t size);
     int               (*send)(void *s);


### PR DESCRIPTION
This new function interrupts any I/O smb_session functions (smb_session_connect, smb_fread...)

This function can be called from any threads. The session is unusable after this call, only smb_session_destroy() should be called after.

This PR also bump the libdsm version to 0.3.3