### PR TITLE
meson: Package and use generated files

### DIFF
--- a/dist_generated.py
+++ b/dist_generated.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python3
+
+import shutil
+import sys
+import os
+
+if __name__ == '__main__':
+    if (len(sys.argv) != 2):
+        print('usage: ', sys.argv[0], ' </path/to/file/to/package>')
+        sys.exit(1)
+    shutil.copy(sys.argv[1], os.getenv('MESON_DIST_ROOT'))
+    

--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project('libdsm', ['c'],
                       'warning_level=2',
                       'buildtype=release',
                       'b_ndebug=if-release'],
-    meson_version: '>= 0.50.0')
+    meson_version: '>= 0.53.0')
 
 #Soname
 dsm_soname_version = '3.1.0'
@@ -167,12 +167,17 @@ config_header = configure_file(
   output: 'config.h',
   configuration: conf_data)
 
-asn1parser_prog = find_program('asn1Parser')
-spnego_asn1_target = custom_target('spnego_asn1.c',
-  input: 'contrib/spnego/spnego.asn1',
-  output: 'spnego_asn1.c',
-  command: [asn1parser_prog, '-o', '@OUTPUT@', '-n', 'spnego_asn1_conf',
-            '@INPUT@'])
+fs_module = import('fs')
+if fs_module.is_file('spnego_asn1.c')
+  spnego_asn1_target = files('spnego_asn1.c')
+else
+  asn1parser_prog = find_program('asn1Parser')
+  spnego_asn1_target = custom_target('spnego_asn1.c',
+    input: 'contrib/spnego/spnego.asn1',
+    output: 'spnego_asn1.c',
+    command: [asn1parser_prog, '-o', '@OUTPUT@', '-n', 'spnego_asn1_conf',
+              '@INPUT@'])
+endif
 
 libdsm_sources = [
   'contrib/mdx/md4.c',

--- a/meson.build
+++ b/meson.build
@@ -168,8 +168,10 @@ config_header = configure_file(
   configuration: conf_data)
 
 fs_module = import('fs')
+package_generated = true
 if fs_module.is_file('spnego_asn1.c')
   spnego_asn1_target = files('spnego_asn1.c')
+  package_generated = false
 else
   asn1parser_prog = find_program('asn1Parser')
   spnego_asn1_target = custom_target('spnego_asn1.c',
@@ -271,4 +273,8 @@ if doxygen.found()
              install_dir: doc_dir)
 else
   warning('Doxygen not found - continuing without Doxygen support')
+endif
+
+if package_generated
+  meson.add_dist_script('dist_generated.py', spnego_asn1_target.full_path())
 endif


### PR DESCRIPTION
This MR aims at packaging the generated files (so far, spnego_asn1.c) in the source tarball, and use it from the root sources directory if available.

This should allow us to completely drop autotools without requiring our users to have the `asn1parser` tool available on their end.