### PR TITLE
Add support for older CIFS tree connect reponse.

### DIFF
--- a/src/smb_packets.h
+++ b/src/smb_packets.h
@@ -185,6 +185,19 @@ SMB_PACKED_START typedef struct
 } SMB_PACKED_END   smb_tree_connect_req;
 
 //<- Tree Connect
+// See: [MS-CIFS] §2.2.4.55.2
+// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/3286744b-5b58-4ad5-b62e-c4f29a2492f1
+SMB_PACKED_START typedef struct
+{
+    uint8_t         wct;              // 3
+    SMB_ANDX_MEMBERS
+    uint16_t        opt_support;
+    uint16_t        bct;
+    uint8_t         payload[];
+} SMB_PACKED_END   smb_tree_connect_resp;
+
+// See [MS-SMB] §2.2.4.7.2
+// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/087860d5-3919-41d5-a753-1b330d651196
 SMB_PACKED_START typedef struct
 {
     uint8_t         wct;              // 7
@@ -194,7 +207,7 @@ SMB_PACKED_START typedef struct
     uint32_t        guest_rights;
     uint16_t        bct;
     uint8_t         payload[];
-} SMB_PACKED_END   smb_tree_connect_resp;
+} SMB_PACKED_END   smb_tree_connect_respx;
 
 //-> Tree Disconnect / <- Tree Disconnect
 typedef smb_simple_struct smb_tree_disconnect_req;


### PR DESCRIPTION
I recently ran into some issues trying to use `libdsm` trying to connect to an old NAS. It turns out that there are two possible responses to an SMB tree connect message: the one defined in [[MS-SMB] §2.2.4.7.2](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/087860d5-3919-41d5-a753-1b330d651196) – that the library can currently handle – and an older, shorter one defined in [[MS-CIFS] §2.2.4.55.2](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/3286744b-5b58-4ad5-b62e-c4f29a2492f1).

This pull request allows `libdsm` to handle either of these responses. 

Older versions of `libdsm`, pre v2.8, could handle these old messages because they were less strict on the length of the reply. 

As far as I can tell, while the library stores the values received in the `max_rights` and `guest_rights` fields (that are not present in the older message), it makes no further use of these, so I don't think merging this pull request would break anything.   