### PR TITLE
meson: ignore undefined warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -40,7 +40,8 @@ optional_arguments = [
   '-Wsign-compare',
   '-Wextra',
   '-Wstrict-aliasing',
-  '-Wstrict-overflow' ]
+  '-Wstrict-overflow',
+  '-Wundef' ]
 
 add_project_arguments(
   cc.get_supported_arguments(optional_arguments),


### PR DESCRIPTION
The undefined warning may not be used at the same time as compiling for
bitcode so disable it as its use is generally limited.

Fixes #158